### PR TITLE
docs: Add gtk.enable to home manager instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Example home configuration:
 # import the carburetor module
 imports = [ inputs.carburetor.homeManagerModules.default ];
 
+# enable home manager gtk module
+gtk.enable = true;
+
 # configure carburetor theme installation
 carburetor = {
   config = {

--- a/docs/home.md
+++ b/docs/home.md
@@ -36,7 +36,7 @@ one of “cool”, “light”, “warm”, “regular”
 
 
 
-Whether to enable installing and configuring gtk themes\.
+Whether to enable installing and configuring gtk themes\. Also requires `gtk.enable = true;`\.
 
 
 
@@ -341,5 +341,3 @@ boolean
 
 *Example:*
 ` true `
-
-

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
                   stateVersion = "24.05";
                 };
 
+                gtk.enable = true;
                 carburetor = {
                   config = {
                     variant = "regular";

--- a/nix/home/gtk.nix
+++ b/nix/home/gtk.nix
@@ -12,7 +12,7 @@
 }:
 {
   options.${name}.themes.gtk = {
-    enable = lib.mkEnableOption "installing and configuring gtk themes";
+    enable = lib.mkEnableOption "installing and configuring gtk themes\. Also requires `gtk.enable = true;`";
     transparency = lib.mkEnableOption "transparency in background colors";
     icon = lib.mkEnableOption "installing patched papirus icons";
     gnomeShellTheme = lib.mkEnableOption "installing gtk theme for GNOME Shell";


### PR DESCRIPTION
When trying to set this up in NixOS, I noticed that you also have to enable GTK management in home manager for the GTK theming to work. This could probably also be solved by instead making the home manager module automatically set `gtk.enable = true` if the gtk segment is enabled.